### PR TITLE
Added magnet links support via cache services.

### DIFF
--- a/ByteFlood/ByteFlood.csproj
+++ b/ByteFlood/ByteFlood.csproj
@@ -73,6 +73,9 @@
     <Compile Include="InfoClasses\PieceInfo.cs" />
     <Compile Include="InfoClasses\TrackerInfo.cs" />
     <Compile Include="Listener.cs" />
+    <Compile Include="Services\TorrentCache\ITorrentCache.cs" />
+    <Compile Include="Services\TorrentCache\TorCache.cs" />
+    <Compile Include="Services\TorrentCache\Torrage.cs" />
     <Compile Include="State.cs" />
     <Compile Include="TorrentProperties.cs" />
     <Compile Include="UI\AddTorrentDialog.xaml.cs">

--- a/ByteFlood/Services/TorrentCache/ITorrentCache.cs
+++ b/ByteFlood/Services/TorrentCache/ITorrentCache.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ByteFlood.Services.TorrentCache
+{
+    public interface ITorrentCache
+    {
+        string Name { get; }
+
+        string Url { get; }
+
+        byte[] Fetch(MonoTorrent.MagnetLink magnet);
+    }
+}

--- a/ByteFlood/Services/TorrentCache/TorCache.cs
+++ b/ByteFlood/Services/TorrentCache/TorCache.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Net;
+
+namespace ByteFlood.Services.TorrentCache
+{
+    public class TorCache : ITorrentCache
+    {
+        public string Name { get { return "TorCache"; } }
+
+        public string Url { get { return "http://torcache.net/"; } }
+
+        public byte[] Fetch(MonoTorrent.MagnetLink magnet)
+        {
+            string url = string.Format("http://torcache.net/torrent/{0}.torrent", magnet.InfoHash.ToHex());
+
+            using (WebClient nc = new WebClient())
+            {
+                nc.Headers.Add(HttpRequestHeader.UserAgent, "Mozilla/18.0 (compatible; MSIE 10.0; Windows NT 5.2; .NET CLR 3.5.3705;)");
+
+                byte[] gzip_data = null;
+
+                try
+                {
+                    gzip_data = nc.DownloadData(url);
+                }
+                catch (WebException wex)
+                {
+                    if (wex.Message.Contains("404"))
+                    {
+                        return null;
+                    }
+                }
+                catch (Exception) { return null; }
+
+                byte[] data = Utility.DecompressGzip(gzip_data);
+
+                return data;
+            }
+        }
+    }
+}

--- a/ByteFlood/Services/TorrentCache/Torrage.cs
+++ b/ByteFlood/Services/TorrentCache/Torrage.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Net;
+
+namespace ByteFlood.Services.TorrentCache
+{
+    public class Torrage : ITorrentCache
+    {
+        public string Name { get { return "Torrage"; } }
+
+        public string Url { get { return "http://torrage.com/"; } }
+
+        public byte[] Fetch(MonoTorrent.MagnetLink magnet)
+        {
+            string url = string.Format("http://torrage.com/torrent/{0}.torrent", magnet.InfoHash.ToHex());
+
+            using (WebClient nc = new WebClient())
+            {
+                nc.Headers.Add(HttpRequestHeader.UserAgent, "Mozilla/18.0 (compatible; MSIE 10.0; Windows NT 5.2; .NET CLR 3.5.3705;)");
+
+                byte[] gzip_data = null;
+
+                try
+                {
+                    gzip_data = nc.DownloadData(url);
+                }
+                catch (WebException wex)
+                {
+                    if (wex.Message.Contains("404"))
+                    {
+                        return null;
+                    }
+                }
+                catch (Exception) { return null; }
+
+                byte[] data = Utility.DecompressGzip(gzip_data);
+
+                return data;
+            }
+        }
+    }
+}

--- a/ByteFlood/UI/MainWindow.xaml.cs
+++ b/ByteFlood/UI/MainWindow.xaml.cs
@@ -159,8 +159,24 @@ namespace ByteFlood
 
         private void Window_Drop(object sender, DragEventArgs e)
         {
-            string toppest = (string)((DataObject)e.Data).GetFileDropList()[0];
-            state.AddTorrentByPath(toppest);
+            var data = ((DataObject)e.Data);
+
+            if (data.ContainsText())
+            {
+                string text = (string)data.GetData(typeof(string));
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    if (text.StartsWith("magnet:?")) 
+                    {
+                       state.AddTorrentByMagnet(text);
+                    }
+                }
+            }
+            else 
+            {
+                string toppest = (string)data.GetFileDropList()[0];
+                state.AddTorrentByPath(toppest);
+            }
         }
         #endregion
 

--- a/ByteFlood/Utility.cs
+++ b/ByteFlood/Utility.cs
@@ -225,5 +225,17 @@ namespace ByteFlood
             XmlReader x = XmlReader.Create(new StringReader(s));
             return (T)new XmlSerializer(typeof(T)).Deserialize(x);
         }
+
+        public static byte[] DecompressGzip(byte[] gzip_data)
+        {
+            using (var stream = new System.IO.Compression.GZipStream(new MemoryStream(gzip_data), System.IO.Compression.CompressionMode.Decompress))
+            {
+                using (MemoryStream memory = new MemoryStream())
+                {
+                    stream.CopyTo(memory);
+                    return memory.ToArray();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Also this fix issue https://github.com/hexafluoride/byteflood/issues/12

This commit add the ability to load magnet links by downloading a cached .torrent file from online torrent cache services such as http://torrage.com and http://torcache.net. Additional services can be added by implementing the `ITorrentCache` interface. This way I download a .torrent file in the default download directory, and load torrent normally by file.

I have not added the code to load torrent without files (pure magnets, no cached .torrent), I left it for you hex so you can do it the way you prefer.
